### PR TITLE
Fix typo in imports (television)

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = function(sails) {
   var init = require('./lib/onkyo.init.js');
   var exec = require('./lib/onkyo.exec.js');
   var update = require('./lib/onkyo.update.js');
-  var television = require('.lib/television/index.js');
+  var television = require('./lib/television/index.js');
 
   gladys.on('ready', function() {
     init();


### PR DESCRIPTION
When installing the module from the gladys backend, I got an error on Gladys restart:
`Error: Cannot find module '.lib/television/index.js'`

It was just a typo in the television import.